### PR TITLE
Hide Progress Bar Column from Patient Listing Page

### DIFF
--- a/mnd/mnd/views/mnd_patients_listing.py
+++ b/mnd/mnd/views/mnd_patients_listing.py
@@ -37,7 +37,6 @@ class MNDPatientsListingView(PatientsListingView):
             ColumnFullName(_("Patient"), "patients.can_see_full_name"),
             ColumnDateOfBirth(_("Date of Birth"), "patients.can_see_dob"),
             ColumnCodeField(_("Gender"), "patients.can_see_code_field"),
-            ColumnDiagnosisProgress(_("Overall Form Progress"), "patients.can_see_diagnosis_progress"),
             ColumnDateLastUpdated(_("Date Last Updated"), "patients.can_see_last_updated_at"),
             ColumnLivingStatus(_("Living Status"), "patients.can_see_living_status"),
             ColumnContextMenu(_("Modules"), "patients.can_see_data_modules"),


### PR DESCRIPTION
This will hide the Progress Column from the Patient Listing Page.

Currently the `firstVisit` form has some form completion CDEs set, so the patient view/edit  page shows a Form Progress bar.
Waiting for an answer to see if we can unset these form completion CDEs on `firstVisit` or extra work needs to be done to also hide the Form Progress bar on the patient view/edit page.