### PR TITLE
[ERE-2123] Rewrite logic to update carer's email address

### DIFF
--- a/mnd/mnd/models.py
+++ b/mnd/mnd/models.py
@@ -99,13 +99,33 @@ class PrimaryCarer(models.Model):
 @receiver(user_email_updated)
 def update_carer_email(sender, user, previous_email, **kwargs):
     if user.is_carer:
-        if carer_patient := Patient.objects.filter(carer=user).first():
-            if primary_carer := carer_patient.primary_carers.first():
-                primary_carer.email = user.email  # Synchronise the carer's email with the user's updated email
+        new_email = user.email
+        for primary_carer in PrimaryCarer.objects.filter(email__iexact=previous_email):
+
+            # Get any deactivated registrations
+            deactivated_registrations = primary_carer.carerregistration_set.filter(status=CarerRegistration.DEACTIVATED)
+            # Get associated relationships
+            relationships_to_disassociate = PrimaryCarerRelationship.objects.filter(
+                carer=primary_carer,
+                patient__in=[r.patient for r in deactivated_registrations]
+            )
+
+            # 1. Force new primary carer in relationship to disassociate from primary carer with new email
+            for relationship in relationships_to_disassociate:
+                rc_copy = relationship.carer
+                rc_copy.pk = None
+                rc_copy.save()
+                relationship.carer = rc_copy
+                relationship.save()
+
+            if active_registrations := primary_carer.carerregistration_set.filter(status__in=[CarerRegistration.CREATED, CarerRegistration.REGISTERED]):
+                # 2. Update active registrations with the new email
+                active_registrations.update(carer_email=new_email)
+
+                # 3. Update this primary carer's email
+                primary_carer.email = new_email
                 primary_carer.save()
 
-        # Update any existing carer registrations for the previous email address
-        CarerRegistration.objects.filter(carer_email__iexact=previous_email).update(carer_email=user.email)
 
 
 class PrimaryCarerRelationship(models.Model):

--- a/mnd/mnd/registry/patients/mnd_admin_forms.py
+++ b/mnd/mnd/registry/patients/mnd_admin_forms.py
@@ -235,7 +235,7 @@ class PrimaryCarerForm(PrefixedModelForm):
         instance = getattr(self, 'instance', None)
         carer_instance_update = False
         if 'email' in self.changed_data:
-            existing_carer = PrimaryCarer.objects.filter(email__iexact=email.lower()).first()
+            existing_carer = PrimaryCarer.objects.filter(email__iexact=email).first()
             if existing_carer:
                 carer_instance_update = True
                 self.instance = existing_carer


### PR DESCRIPTION
 * make better use of existing relationships
 * disassociate a primary carer from a relationship where an active registration does not exist
 * only update primary carer email if an active registration exists