### PR TITLE
[ERP-4395] Use same uwsgi config as base trrf

### DIFF
--- a/uwsgi/django.wsgi
+++ b/uwsgi/django.wsgi
@@ -1,11 +1,21 @@
 # Generic WSGI application
 import os
+import uwsgi
 from django.core.wsgi import get_wsgi_application
 
+wsgi_application = get_wsgi_application()
+
 def application(environ, start):
+    response = wsgi_application(environ,start)
+    user_id = str(response.user_id) if hasattr(response, 'user_id') else ''
+    app = uwsgi.workers()[0]['apps'][0]['id']
+    current_req = uwsgi.request_id() + 1
+    total_req = uwsgi.total_requests() + 1
 
-    # copy any vars into os.environ
-    for key in environ:
-        os.environ[key] = str(environ[key])
+    uwsgi.set_logvar('user_id', user_id)
+    uwsgi.set_logvar('app', str(app))
+    uwsgi.set_logvar('current_req', str(current_req))
+    uwsgi.set_logvar('total_req', str(total_req))
 
-    return get_wsgi_application()(environ,start)
+    return response
+

--- a/uwsgi/django.wsgi
+++ b/uwsgi/django.wsgi
@@ -1,5 +1,4 @@
 # Generic WSGI application
-import os
 import uwsgi
 from django.core.wsgi import get_wsgi_application
 

--- a/uwsgi/django.wsgi
+++ b/uwsgi/django.wsgi
@@ -5,7 +5,7 @@ from django.core.wsgi import get_wsgi_application
 wsgi_application = get_wsgi_application()
 
 def application(environ, start):
-    response = wsgi_application(environ,start)
+    response = wsgi_application(environ, start)
     user_id = str(response.user_id) if hasattr(response, 'user_id') else ''
     app = uwsgi.workers()[0]['apps'][0]['id']
     current_req = uwsgi.request_id() + 1

--- a/uwsgi/docker.ini
+++ b/uwsgi/docker.ini
@@ -5,3 +5,4 @@
 emperor      = /app/uwsgi/vassals
 touch-reload = /app/uwsgi/docker.ini
 vacuum       = True
+log-format   = [pid: %(pid)|app: %(app)|req: %(current_req)/%(total_req)] [user_id: %(user_id)]  %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))


### PR DESCRIPTION
Creating the `get_wsgi_application` on each request was causing a large memory drain in the new architecture, possibly due to different `.so` loading strategies used in the new `uv` style dockerfiles. But it was probably also causing perf issues before the switch to uv anyway, this just tipped them over the edge.

This change brings in the changes that @Lexiel46 added to TRRF a while ago in eresearchqut/trrf#673, that never made it into the registries themselves.

Also note my previous comment in that PR, so there might still be some lingering issue: https://github.com/eresearchqut/trrf/pull/673/changes#r1503456754. I can see that adding that `--ini "${UWSGI_OPTS}"` arg appears to spawn an additional uwsgi process, which I think is the unused `socket-9100` vassal + one of the processes becomes an 'emporer', so I will investigate that in a separate PR to TRRF.

Once approved, I'll benchmark memory usage again, and then make these same changes in arrk and the cookiecutter project