### PR TITLE
[ERP-4736] Fix patient edit page crash for self-registered patients

### DIFF
--- a/mnd/mnd/registry/patients/mnd_admin_forms.py
+++ b/mnd/mnd/registry/patients/mnd_admin_forms.py
@@ -214,7 +214,7 @@ class PrimaryCarerForm(PrefixedModelForm):
 
     def has_assigned_carer(self):
         instance = getattr(self, "instance")
-        if instance and self.patient:
+        if instance and instance.pk and self.patient:
             return CarerRegistration.objects.has_registered_carer(
                 instance, self.patient
             )


### PR DESCRIPTION
has_assigned_carer() was passing an unsaved PrimaryCarer instance (no PK) to a related ORM filter for patients with no PrimaryCarerRelationship (e.g. self-registered patients). This silently no-op'd in Django 4.x but raises a hard ValueError in Django 5.0+.

Add an instance.pk guard so unsaved instances short-circuit to False.